### PR TITLE
Fix the code to build on Visual Studio 2019-22 and raylib dev

### DIFF
--- a/src/assets.cpp
+++ b/src/assets.cpp
@@ -61,9 +61,9 @@ Assets::Assets()
             if ((((x / BLOCK_SIZE) % 2) == 0 && ((y / BLOCK_SIZE) % 2) == 0) ||
                 (((x / BLOCK_SIZE) % 2) == 1 && ((y / BLOCK_SIZE) % 2) == 1) )
             {
-                pixels[base] = 0xFF;
+                pixels[base] = char(0xFF);
                 pixels[base + 1] = 0x00;
-                pixels[base + 2] = 0xFF;
+                pixels[base + 2] = char(0xFF);
             }
             else
             {
@@ -225,10 +225,10 @@ const Texture2D &Assets::GetShapeIcon(ModelID modelID)
 
 void Assets::RedrawIcons()
 {
-    static Camera camera = (Camera) {
-        .position = (Vector3) { 4.0f, 4.0f, 4.0f },
+    static Camera camera = Camera {
+        .position = Vector3 { 4.0f, 4.0f, 4.0f },
         .target = Vector3Zero(),
-        .up = (Vector3) { 0.0f, -1.0f, 0.0f },
+        .up = Vector3 { 0.0f, -1.0f, 0.0f },
         .fovy = 45.0f,
         .projection = CAMERA_PERSPECTIVE
     };
@@ -240,7 +240,7 @@ void Assets::RedrawIcons()
         ClearBackground(BLACK);
         BeginMode3D(camera);
 
-        DrawModelWiresEx(_Get()->ModelFromID(modelID), Vector3Zero(), (Vector3){0.0f, 1.0f, 0.0f}, GetTime() * 180.0f, Vector3One(), GREEN);
+        DrawModelWiresEx(_Get()->ModelFromID(modelID), Vector3Zero(), Vector3{0.0f, 1.0f, 0.0f}, float(GetTime() * 180.0f), Vector3One(), GREEN);
 
         EndMode3D();
         EndTextureMode();

--- a/src/dialogs.cpp
+++ b/src/dialogs.cpp
@@ -123,7 +123,7 @@ bool NewMapDialog::Draw()
     //Size spinners
     for (int i = 0; i < NUM_SPINNERS; ++i)
     {
-        Rectangle spRec = (Rectangle) { 
+        Rectangle spRec = Rectangle { 
             .x = dRect.x + MARGIN + i * (SPINNER_W + SPINNER_SEP), 
             .y = dRect.y + DHH - SPINNER_HH, 
             .width = SPINNER_W, 
@@ -133,7 +133,7 @@ bool NewMapDialog::Draw()
         {
             _spinnerActive[i] = !_spinnerActive[i];
         }
-        GuiLabel((Rectangle) { .x = spRec.x, .y = spRec.y - MARGIN }, SPINNER_LABELS[i]);
+        GuiLabel(Rectangle { .x = spRec.x, .y = spRec.y - MARGIN }, SPINNER_LABELS[i]);
     }
 
     //Confirm button
@@ -177,8 +177,8 @@ bool ExpandMapDialog::Draw()
     }
 
     std::vector<Rectangle> recs = ArrangeHorzCentered(dRect, {
-        (Rectangle) { .width = 128.0f, .height = 32.0f }, //Direction chooser
-        (Rectangle) { .width = 96.0f, .height = 32.0f } //Amount spinner
+        Rectangle { .width = 128.0f, .height = 32.0f }, //Direction chooser
+        Rectangle { .width = 96.0f, .height = 32.0f } //Amount spinner
     });
 
     //Direction chooser
@@ -186,14 +186,14 @@ bool ExpandMapDialog::Draw()
     {
         _chooserActive = !_chooserActive;
     }
-    GuiLabel((Rectangle) { .x = recs[0].x, .y = recs[0].y - MARGIN }, "Direction");
+    GuiLabel(Rectangle { .x = recs[0].x, .y = recs[0].y - MARGIN }, "Direction");
 
     //Amount spinner
     if (GuiSpinner(recs[1], "", &_amount, 1, 1000, _spinnerActive))
     {
         _spinnerActive = !_spinnerActive;
     }
-    GuiLabel((Rectangle) { .x = recs[1].x, .y = recs[1].y - MARGIN }, "# of cels");
+    GuiLabel(Rectangle { .x = recs[1].x, .y = recs[1].y - MARGIN }, "# of cels");
 
 
     return !clicked;
@@ -219,14 +219,14 @@ bool FileDialog::Draw()
     const Rectangle DRECT = DialogRec(512.0f, 400.0f);
     bool clicked = GuiWindowBox(DRECT, _title.c_str());
 
-    const Rectangle FILE_ENTRY_RECT = (Rectangle) { 
+    const Rectangle FILE_ENTRY_RECT = Rectangle { 
         .x = DRECT.x + 4.0f, 
         .y = DRECT.y + DRECT.height - 24.0f, 
         .width = DRECT.width - 64.0f - 8.0f, 
         .height = 20.0f
     };
 
-    const Rectangle FILES_RECT = (Rectangle) {
+    const Rectangle FILES_RECT = Rectangle {
         .x = DRECT.x + 4.0f,
         .y = DRECT.y + 28.0f,
         .width = DRECT.width - 8.0f,
@@ -234,7 +234,7 @@ bool FileDialog::Draw()
     };
 
     //Collect file information to display on the screen
-    Rectangle content = (Rectangle) { .width = FILES_RECT.width - 8.0f, .height = 8.0f };
+    Rectangle content = Rectangle { .width = FILES_RECT.width - 8.0f, .height = 8.0f };
     std::map<const fs::directory_entry, Rectangle> fileRects;
 
     const float FILE_RECT_HEIGHT = 16.0f;
@@ -243,7 +243,7 @@ bool FileDialog::Draw()
     //Add the parent directory to the list of files as [parent folder]
     if (_currentDir.has_parent_path())
     {
-        fileRects[fs::directory_entry(_currentDir.parent_path())] = (Rectangle) { 4.0f, y, content.width - 8.0f, FILE_RECT_HEIGHT };
+        fileRects[fs::directory_entry(_currentDir.parent_path())] = Rectangle { 4.0f, y, content.width - 8.0f, FILE_RECT_HEIGHT };
         y += FILE_RECT_HEIGHT;
         content.height += FILE_RECT_HEIGHT;
     }
@@ -254,7 +254,7 @@ bool FileDialog::Draw()
         if (entry.is_directory() || 
             (entry.is_regular_file() && _extensions.find(entry.path().extension().string()) != _extensions.end()))
         {
-            Rectangle fileRect = (Rectangle) {
+            Rectangle fileRect = Rectangle {
                 .x = 4.0f,
                 .y = y,
                 .width = content.width - 8.0f,
@@ -268,7 +268,7 @@ bool FileDialog::Draw()
 
     //Directory view drawing
     Rectangle scissor = GuiScrollPanel(FILES_RECT, NULL, content, &_scroll);
-    BeginScissorMode(scissor.x, scissor.y, scissor.width, scissor.height);
+    BeginScissorMode(scissor.x, scissor.y, int(scissor.width), int(scissor.height));
 
     for (auto const& [entry, rect] : fileRects)
     {
@@ -282,7 +282,7 @@ bool FileDialog::Draw()
             name = entry.path().filename().string();
         }
 
-        const Rectangle BUTT_RECT = (Rectangle) { 
+        const Rectangle BUTT_RECT = Rectangle { 
             .x = scissor.x + rect.x + _scroll.x, 
             .y = scissor.y + rect.y + _scroll.y, 
             .width = rect.width, 
@@ -313,7 +313,7 @@ bool FileDialog::Draw()
     }
 
     //Select button
-    const Rectangle SELECT_BUTT_RECT = (Rectangle) {
+    const Rectangle SELECT_BUTT_RECT = Rectangle {
         .x = FILE_ENTRY_RECT.x + FILE_ENTRY_RECT.width + 4.0f,
         .y = FILE_ENTRY_RECT.y,
         .width = DRECT.width - (SELECT_BUTT_RECT.x - DRECT.x) - 4.0f,
@@ -379,40 +379,40 @@ bool AssetPathDialog::Draw()
     
     bool clicked = GuiWindowBox(DRECT, "Asset Paths");
 
-    const Rectangle TEX_PATH_BOX = (Rectangle) {
+    const Rectangle TEX_PATH_BOX = Rectangle {
         .x = DRECT.x + 8.0f,
         .y = DRECT.y + 8.0f + 32.0f + 12.0f,
         .width = DRECT.width - (TEX_PATH_BOX.x - DRECT.x) - 16.0f,
         .height = 24.0f
     };
 
-    GuiLabel((Rectangle){ TEX_PATH_BOX.x, TEX_PATH_BOX.y - 12.0f }, "Textures Path");
+    GuiLabel(Rectangle{ TEX_PATH_BOX.x, TEX_PATH_BOX.y - 12.0f }, "Textures Path");
     if (GuiTextBox(TEX_PATH_BOX, _texPathBuffer, TEXT_FIELD_MAX, _texPathEdit))
     {
         _texPathEdit = !_texPathEdit;
     }
 
-    const Rectangle SHAPE_PATH_BOX = (Rectangle) {
+    const Rectangle SHAPE_PATH_BOX = Rectangle {
         .x = TEX_PATH_BOX.x,
         .y = TEX_PATH_BOX.y + TEX_PATH_BOX.height + 24.0f,
         .width = TEX_PATH_BOX.width,
         .height = TEX_PATH_BOX.height
     };
-    GuiLabel((Rectangle) { SHAPE_PATH_BOX.x, SHAPE_PATH_BOX.y - 12.0f }, "Shapes Path");
+    GuiLabel(Rectangle { SHAPE_PATH_BOX.x, SHAPE_PATH_BOX.y - 12.0f }, "Shapes Path");
     if (GuiTextBox(SHAPE_PATH_BOX, _shapePathBuffer, TEXT_FIELD_MAX, _shapePathEdit))
     {
         _shapePathEdit = !_shapePathEdit;
     }
 
-    const Rectangle BUTTON_REGION = (Rectangle) {
+    const Rectangle BUTTON_REGION = Rectangle {
         .x = DRECT.x + 8.0f,
         .y = DRECT.y + DRECT.height - 48.0f,
         .width = DRECT.width - (BUTTON_REGION.x - DRECT.x) - 8.0f,
         .height = 48.0f
     };
     std::vector<Rectangle> buttonRecs = ArrangeHorzCentered(BUTTON_REGION, { 
-        (Rectangle){ .width = 96.0f, .height = 32.0f }, 
-        (Rectangle){ .width = 96.0f, .height = 32.0f } });
+        Rectangle{ .width = 96.0f, .height = 32.0f }, 
+        Rectangle{ .width = 96.0f, .height = 32.0f } });
 
     if (GuiButton(buttonRecs[0], "Confirm"))
     {
@@ -459,30 +459,30 @@ bool SettingsDialog::Draw()
 
     bool clicked = GuiWindowBox(DRECT, "Settings");
 
-    const Rectangle SETTINGS_RECT = (Rectangle) { DRECT.x + 8.0f, DRECT.y + 32.0f, DRECT.width - 16.0f, DRECT.height - 64.0f };
+    const Rectangle SETTINGS_RECT = Rectangle { DRECT.x + 8.0f, DRECT.y + 32.0f, DRECT.width - 16.0f, DRECT.height - 64.0f };
     std::vector<Rectangle> recs = ArrangeVertical(
         SETTINGS_RECT,
         {
-            (Rectangle) { .x = 16.0f, .width = 128.0f, .height = 32.0f }, //0: Undo max
-            (Rectangle) { .x = 16.0f, .width = SETTINGS_RECT.width - 64.0f, .height = 32.0f }  //1: Sensitivity
+            Rectangle { .x = 16.0f, .width = 128.0f, .height = 32.0f }, //0: Undo max
+            Rectangle { .x = 16.0f, .width = SETTINGS_RECT.width - 64.0f, .height = 32.0f }  //1: Sensitivity
         }
     );
 
-    GuiLabel((Rectangle) { recs[0].x, recs[0].y - 12.0f }, "Max Undo Count");
+    GuiLabel(Rectangle { recs[0].x, recs[0].y - 12.0f }, "Max Undo Count");
     if (GuiSpinner(recs[0], "", &_undoMax, 1, 1000, _undoMaxEdit))
     {
         _undoMaxEdit = !_undoMaxEdit;
     }
 
-    GuiLabel((Rectangle) { recs[1].x, recs[1].y - 12.0f }, TextFormat("Mouse sensitivity: %.2f", _sensitivity));
+    GuiLabel(Rectangle { recs[1].x, recs[1].y - 12.0f }, TextFormat("Mouse sensitivity: %.2f", _sensitivity));
     _sensitivity = GuiSlider(recs[1], "", "", _sensitivity, 0.05f, 10.0f);
     _sensitivity = floorf(_sensitivity / 0.05f) * 0.05f;
 
     //Confirm buttons
-    const Rectangle BUTT_GROUP = (Rectangle) { DRECT.x + 8.0f, DRECT.y + DRECT.height - 8.0f - 32.0f, DRECT.width - 16.0f, 32.0f };
+    const Rectangle BUTT_GROUP = Rectangle { DRECT.x + 8.0f, DRECT.y + DRECT.height - 8.0f - 32.0f, DRECT.width - 16.0f, 32.0f };
     std::vector<Rectangle> buttRecs = ArrangeHorzCentered(BUTT_GROUP, {
-        (Rectangle) { .width = 128.0f, .height = 32.0f }, //0: Confirm
-        (Rectangle) { .width = 128.0f, .height = 32.0f }  //1: Cancel
+        Rectangle { .width = 128.0f, .height = 32.0f }, //0: Confirm
+        Rectangle { .width = 128.0f, .height = 32.0f }  //1: Cancel
     });
 
     if (GuiButton(buttRecs[0], "Confirm"))
@@ -508,10 +508,10 @@ bool AboutDialog::Draw()
     bool clicked = GuiWindowBox(DRECT, "About");
 
     Font font = Assets::GetFont();
-    DrawTextEx(font, "Total Editor 3.0.0", (Vector2) { DRECT.x + 8.0f, DRECT.y + 32.0f }, 32.0f, 0.25f, WHITE);
+    DrawTextEx(font, "Total Editor 3.0.0", Vector2 { DRECT.x + 8.0f, DRECT.y + 32.0f }, 32.0f, 0.25f, WHITE);
 
-    DrawTextEx(font, "Written by The Tophat Demon", (Vector2) { DRECT.x + 8.0f, DRECT.y + 70.0f }, font.baseSize, 0.0f, WHITE);
-    DrawTextEx(font, "Source code: \nhttps://github.com/TheTophatDemon/Total-Editor-3", (Vector2) { DRECT.x + 8.0f, DRECT.y + 96.0f }, font.baseSize, 0.0f, WHITE);
+    DrawTextEx(font, "Written by The Tophat Demon", Vector2 { DRECT.x + 8.0f, DRECT.y + 70.0f }, font.baseSize, 0.0f, WHITE);
+    DrawTextEx(font, "Source code: \nhttps://github.com/TheTophatDemon/Total-Editor-3", Vector2 { DRECT.x + 8.0f, DRECT.y + 96.0f }, font.baseSize, 0.0f, WHITE);
 
     return !clicked;
 }
@@ -557,7 +557,7 @@ bool ShortcutsDialog::Draw()
 
     bool clicked = GuiWindowBox(DRECT, "Shortcuts");
 
-    Rectangle contentRect = (Rectangle) { 0 };
+    Rectangle contentRect = Rectangle { 0 };
     const float TEXT_HEIGHT = 32.0f;
     contentRect.height = 16.0f;
     for (int i = 0; i < N_SHORTCUTS; ++i)
@@ -570,14 +570,14 @@ bool ShortcutsDialog::Draw()
     contentRect.width += 100.0f;
 
     Rectangle scissor = GuiScrollPanel(
-        (Rectangle) { DRECT.x + 8.0f, DRECT.y + 32.0f, DRECT.width - 16.0f, DRECT.height - 40.0f }, 
+        Rectangle { DRECT.x + 8.0f, DRECT.y + 32.0f, DRECT.width - 16.0f, DRECT.height - 40.0f }, 
         NULL, contentRect, &_scroll);
 
     BeginScissorMode((int)scissor.x, (int)scissor.y, (int)scissor.width, (int)scissor.height);
 
     for (int i = 0; i < N_SHORTCUTS; ++i)
     {
-        GuiLabel((Rectangle) { scissor.x + _scroll.x, scissor.y + _scroll.y + 16.0f + (i * TEXT_HEIGHT) }, SHORTCUTS_TEXT[i]);
+        GuiLabel(Rectangle { scissor.x + _scroll.x, scissor.y + _scroll.y + 16.0f + (i * TEXT_HEIGHT) }, SHORTCUTS_TEXT[i]);
     }
 
     EndScissorMode();
@@ -591,7 +591,7 @@ bool InstructionsDialog::Draw()
 
     bool clicked = GuiWindowBox(DRECT, "Instructions");
 
-    GuiLabel((Rectangle){ .x = DRECT.x + 8.0f, .y = DRECT.y + 64.0f }, "Please refer to the file \n'instructions.html' included with the application.");
+    GuiLabel(Rectangle{ .x = DRECT.x + 8.0f, .y = DRECT.y + 64.0f }, "Please refer to the file \n'instructions.html' included with the application.");
 
     return !clicked;
 }
@@ -614,16 +614,16 @@ bool ExportDialog::Draw()
 
     bool clicked = GuiWindowBox(DRECT, "Export .gltf scene");
 
-    const Rectangle FILEPATH_RECT = (Rectangle) { DRECT.x + 8.0f, DRECT.y + 48.0f, DRECT.width - 16.0f, 24.0f };
+    const Rectangle FILEPATH_RECT = Rectangle { DRECT.x + 8.0f, DRECT.y + 48.0f, DRECT.width - 16.0f, 24.0f };
     strcpy(_filePathBuffer, _settings.exportFilePath.c_str());
     if (GuiTextBox(FILEPATH_RECT, _filePathBuffer, TEXT_FIELD_MAX, _filePathEdit))
     {
         _filePathEdit = !_filePathEdit;
     }   
     _settings.exportFilePath = _filePathBuffer;
-    GuiLabel((Rectangle) { .x = FILEPATH_RECT.x, .y = FILEPATH_RECT.y - 12.0f }, "File path");
+    GuiLabel(Rectangle { .x = FILEPATH_RECT.x, .y = FILEPATH_RECT.y - 12.0f }, "File path");
 
-    const Rectangle BROWSE_BUTT_RECT = (Rectangle) { FILEPATH_RECT.x, FILEPATH_RECT.y + FILEPATH_RECT.height + 4.0f, 128.0f, 32.0f };
+    const Rectangle BROWSE_BUTT_RECT = Rectangle { FILEPATH_RECT.x, FILEPATH_RECT.y + FILEPATH_RECT.height + 4.0f, 128.0f, 32.0f };
     if (GuiButton(BROWSE_BUTT_RECT, "Browse"))
     {
         _dialog.reset(new FileDialog(std::string("Save .GLTF file"), {std::string(".gltf")}, [&](fs::path path){
@@ -631,10 +631,10 @@ bool ExportDialog::Draw()
         }));
     }
 
-    const Rectangle SEP_BUTT_RECT = (Rectangle) { BROWSE_BUTT_RECT.x, BROWSE_BUTT_RECT.y + BROWSE_BUTT_RECT.height + 32.0f, 32.0f, 32.0f };
-    _settings.exportSeparateGeometry = GuiCheckBox(SEP_BUTT_RECT, "Seperate nodes for each texture", _settings.exportSeparateGeometry);
+    const Rectangle SEP_BUTT_RECT = Rectangle { BROWSE_BUTT_RECT.x, BROWSE_BUTT_RECT.y + BROWSE_BUTT_RECT.height + 32.0f, 32.0f, 32.0f };
+    _settings.exportSeparateGeometry = GuiCheckBox(SEP_BUTT_RECT, "Separate nodes for each texture", _settings.exportSeparateGeometry);
 
-    const Rectangle EXPORT_BUTT_RECT = (Rectangle) { DRECT.x + DRECT.width / 2.0f - 64.0f, DRECT.y + DRECT.height - 40.0f, 128.0f, 32.0f };
+    const Rectangle EXPORT_BUTT_RECT = Rectangle { DRECT.x + DRECT.width / 2.0f - 64.0f, DRECT.y + DRECT.height - 40.0f, 128.0f, 32.0f };
     if (GuiButton(EXPORT_BUTT_RECT, "Export"))
     {
         App::Get()->TryExportMap(fs::path(_settings.exportFilePath), _settings.exportSeparateGeometry);

--- a/src/ent.cpp
+++ b/src/ent.cpp
@@ -74,14 +74,14 @@ void EntGrid::DrawLabels(Camera &camera, int fromY, int toY)
                             std::string name = _grid[i].properties.at("name");
 
                             float fontSize = Assets::GetFont().baseSize;
-                            Vector2 projectPos = (Vector2){ (float)GetScreenWidth() * (ndc.x + 1.0f) / 2.0f, (float)GetScreenHeight() * (ndc.y + 1.0f) / 2.0f };
+                            Vector2 projectPos = Vector2{ (float)GetScreenWidth() * (ndc.x + 1.0f) / 2.0f, (float)GetScreenHeight() * (ndc.y + 1.0f) / 2.0f };
                             int stringWidth = GetStringWidth(Assets::GetFont(), fontSize, name);
 
                             float labelX = projectPos.x - (float)stringWidth / 2.0f;
                             float labelY = projectPos.y - fontSize / 2.0f;
 
                             DrawRectangle((int)labelX, (int)labelY, (float)stringWidth, fontSize, BLACK);
-                            DrawTextEx(Assets::GetFont(), name.c_str(), (Vector2) { labelX, labelY }, fontSize, 0.0f, WHITE);
+                            DrawTextEx(Assets::GetFont(), name.c_str(), Vector2 { labelX, labelY }, fontSize, 0.0f, WHITE);
                         }
                     }
                 }
@@ -117,8 +117,8 @@ void to_json(nlohmann::json& j, const Ent &ent)
 void from_json(const nlohmann::json& j, Ent &ent)
 {
     ent.radius = j.at("radius");
-    ent.color = (Color) { j.at("color").at(0), j.at("color").at(1), j.at("color").at(2), 255 };
-    ent.position = (Vector3) { j.at("position").at(0), j.at("position").at(1), j.at("position").at(2) };
+    ent.color = Color { j.at("color").at(0), j.at("color").at(1), j.at("color").at(2), 255 };
+    ent.position = Vector3 { j.at("position").at(0), j.at("position").at(1), j.at("position").at(2) };
     ent.pitch = j.at("angles").at(0);
     ent.yaw = j.at("angles").at(1);
     ent.properties = j.at("properties");

--- a/src/ent.hpp
+++ b/src/ent.hpp
@@ -80,7 +80,7 @@ public:
 
     //Creates ent grid of given dimensions, default spacing.
     inline EntGrid(size_t width, size_t height, size_t length)
-        : Grid<Ent>(width, height, length, ENT_SPACING_DEFAULT, (Ent) { 0 }) //Nullptr means no entity in the cel
+        : Grid<Ent>(width, height, length, ENT_SPACING_DEFAULT, Ent { 0 }) //Nullptr means no entity in the cel
     {
     }
 
@@ -92,7 +92,7 @@ public:
 
     inline void RemoveEnt(int i, int j, int k)
     {
-        SetCel(i, j, k, (Ent) { 0 });
+        SetCel(i, j, k, Ent { 0 });
     }
     
     inline bool HasEnt(int i, int j, int k) const
@@ -115,7 +115,7 @@ public:
     inline EntGrid Subsection(int i, int j, int k, int w, int h, int l) const
     {
         assert(i >= 0 && j >= 0 && k >= 0);
-        assert(i + w <= _width && j + h <= _height && k + l <= _length);
+        assert(i + w <= int(_width) && j + h <= int(_height) && k + l <= int(_length));
 
         EntGrid newGrid(w, h, l);
 

--- a/src/ent_mode.cpp
+++ b/src/ent_mode.cpp
@@ -67,21 +67,21 @@ void EntMode::Update()
 
 void EntMode::Draw()
 {
-    const Rectangle DRECT = (Rectangle){ 0.0f, 32.0f, (float)GetScreenWidth(), (float)GetScreenHeight() - 32.0f };
+    const Rectangle DRECT = Rectangle{ 0.0f, 32.0f, (float)GetScreenWidth(), (float)GetScreenHeight() - 32.0f };
     
-    const Rectangle APPEAR_RECT = (Rectangle) {
+    const Rectangle APPEAR_RECT = Rectangle {
         DRECT.x + 8.0f, DRECT.y + 8.0f, DRECT.width - 16.0f, 128.0f
     };
 
     //Appearance configuration
 
     //Color picker for empty entities.
-    const Rectangle COLOR_RECT = (Rectangle) { APPEAR_RECT.x, APPEAR_RECT.y, 128.0f, APPEAR_RECT.height };
+    const Rectangle COLOR_RECT = Rectangle { APPEAR_RECT.x, APPEAR_RECT.y, 128.0f, APPEAR_RECT.height };
     Color newColor = GuiColorPicker(COLOR_RECT, "Color", _ent.color);
     _ent.color = newColor;
 
     //Radius slider
-    const Rectangle RADIUS_RECT = (Rectangle) { 
+    const Rectangle RADIUS_RECT = Rectangle { 
         .x = COLOR_RECT.x + COLOR_RECT.width + 64.0f + 4.0f, 
         .y = COLOR_RECT.y + COLOR_RECT.height / 2.0f - 16.0f, 
         .width = APPEAR_RECT.width - (RADIUS_RECT.x - DRECT.x) - 32.0f, 
@@ -91,10 +91,10 @@ void EntMode::Draw()
     _ent.radius = floorf(_ent.radius / 0.05f) * 0.05f;
     char radiusLabel[256];
     sprintf(radiusLabel, "Radius: %.2f", _ent.radius);
-    GuiLabel((Rectangle) { RADIUS_RECT.x, RADIUS_RECT.y - 12 }, radiusLabel);
+    GuiLabel(Rectangle { RADIUS_RECT.x, RADIUS_RECT.y - 12 }, radiusLabel);
 
     //Property list
-    Rectangle SCROLL_RECT = (Rectangle) {
+    Rectangle SCROLL_RECT = Rectangle {
         DRECT.x + 8.0f, APPEAR_RECT.y + APPEAR_RECT.height + 8.0f, DRECT.width - 16.0f, DRECT.height - 8.0f - (SCROLL_RECT.y - DRECT.y) - 64.0f - 4.0f
     };
     const float PROP_HEIGHT = 24.0f;
@@ -107,7 +107,7 @@ void EntMode::Draw()
     }
 
     Rectangle scissor = GuiScrollPanel(SCROLL_RECT, "Properties", 
-        (Rectangle) { .width = Max((int)SCROLL_RECT.width - 16, DRECT.width / 2 + longestStringLen * 12), .height = (PROP_HEIGHT * _ent.properties.size()) + 8.0f }, 
+        Rectangle { .width = float(Max(int(SCROLL_RECT.width - 16), int(DRECT.width / 2) + longestStringLen * 12)), .height = (PROP_HEIGHT * _ent.properties.size()) + 8.0f }, 
         &_propsScroll);
     
     BeginScissorMode(scissor.x, scissor.y, scissor.width, scissor.height);
@@ -115,13 +115,13 @@ void EntMode::Draw()
     float y = 4.0f;
     for (auto [key, val] : _ent.properties)
     {
-        const Rectangle KEY_RECT = (Rectangle) { scissor.x + 4.0f + _propsScroll.x, scissor.y + y + _propsScroll.y, (scissor.width - 16.0f) / 2.0f, PROP_HEIGHT };
+        const Rectangle KEY_RECT = Rectangle { scissor.x + 4.0f + _propsScroll.x, scissor.y + y + _propsScroll.y, (scissor.width - 16.0f) / 2.0f, PROP_HEIGHT };
         if (GuiLabelButton(KEY_RECT, key.c_str()))
         {
             //Copy key name field when a key is clicked in the list.
             strcpy(_keyName, key.c_str());
         }
-        const Rectangle VAL_RECT = (Rectangle) { KEY_RECT.x + KEY_RECT.width + 4.0f, KEY_RECT.y, Max(KEY_RECT.width, longestStringLen * 12), PROP_HEIGHT };
+        const Rectangle VAL_RECT = Rectangle { KEY_RECT.x + KEY_RECT.width + 4.0f, KEY_RECT.y, float(Max(KEY_RECT.width, longestStringLen * 12)), PROP_HEIGHT };
         if (GuiTextBox(VAL_RECT, _propBuffers[key], TEXT_FIELD_MAX, _propEditing[key]))
         {
             _propEditing[key] = !_propEditing[key];
@@ -133,8 +133,8 @@ void EntMode::Draw()
     EndScissorMode();
 
     //Key add/remove widgets
-    const Rectangle ADD_KEY_RECT = (Rectangle) { SCROLL_RECT.x, SCROLL_RECT.y + SCROLL_RECT.height, 32, 32 };
-    const Rectangle REM_KEY_RECT = (Rectangle) { ADD_KEY_RECT.x + ADD_KEY_RECT.width + 4.0f, ADD_KEY_RECT.y, 32, 32 };
+    const Rectangle ADD_KEY_RECT = Rectangle { SCROLL_RECT.x, SCROLL_RECT.y + SCROLL_RECT.height, 32, 32 };
+    const Rectangle REM_KEY_RECT = Rectangle { ADD_KEY_RECT.x + ADD_KEY_RECT.width + 4.0f, ADD_KEY_RECT.y, 32, 32 };
     if (GuiButton(ADD_KEY_RECT, "+"))
     {
         //Add key
@@ -157,14 +157,14 @@ void EntMode::Draw()
         }
     }
     //Key name input field
-    const Rectangle KEY_NAME_RECT = (Rectangle) { REM_KEY_RECT.x + REM_KEY_RECT.width + 4.0f, REM_KEY_RECT.y, DRECT.width - (KEY_NAME_RECT.x - DRECT.x) - 8.0f, 32.0f };
+    const Rectangle KEY_NAME_RECT = Rectangle { REM_KEY_RECT.x + REM_KEY_RECT.width + 4.0f, REM_KEY_RECT.y, DRECT.width - (KEY_NAME_RECT.x - DRECT.x) - 8.0f, 32.0f };
     if (GuiTextBox(KEY_NAME_RECT, _keyName, TEXT_FIELD_MAX, _keyNameEdit))
     {
         _keyNameEdit = !_keyNameEdit;
     }
 
     //Confirm button
-    if (GuiButton((Rectangle) { .x = DRECT.x + (DRECT.width / 2.0f) - 64.0f, .y = DRECT.y + DRECT.height - 32.0f - 8.0f, .width = 128.0f, .height = 32.0f }, "Place"))
+    if (GuiButton(Rectangle { .x = DRECT.x + (DRECT.width / 2.0f) - 64.0f, .y = DRECT.y + DRECT.height - 32.0f - 8.0f, .width = 128.0f, .height = 32.0f }, "Place"))
     {
         _changeConfirmed = true;
         App::Get()->ChangeEditorMode(App::Mode::PLACE_TILE);

--- a/src/grid.hpp
+++ b/src/grid.hpp
@@ -64,7 +64,7 @@ public:
     {
         if (center) 
         {
-            return (Vector3) {
+            return Vector3 {
                 (gridPos.x * _spacing) + (_spacing / 2.0f),
                 (gridPos.y * _spacing) + (_spacing / 2.0f),
                 (gridPos.z * _spacing) + (_spacing / 2.0f),
@@ -110,12 +110,12 @@ public:
     
     inline Vector3 GetMaxCorner() const 
     {
-        return (Vector3) { (float)_width * _spacing, (float)_height * _spacing, (float)_length * _spacing };
+        return Vector3 { (float)_width * _spacing, (float)_height * _spacing, (float)_length * _spacing };
     }
 
     inline Vector3 GetCenterPos() const 
     {
-        return (Vector3) { (float)_width * _spacing / 2.0f, (float)_height * _spacing / 2.0f, (float)_length * _spacing / 2.0f };
+        return Vector3 { (float)_width * _spacing / 2.0f, (float)_height * _spacing / 2.0f, (float)_length * _spacing / 2.0f };
     }
 
 protected:

--- a/src/map_man.cpp
+++ b/src/map_man.cpp
@@ -26,6 +26,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <limits>
 
 #include "app.hpp"
 #include "assets.hpp"
@@ -67,7 +68,7 @@ void MapMan::ExecuteTileAction(size_t i, size_t j, size_t k, size_t w, size_t h,
 
 void MapMan::ExecuteEntPlacement(int i, int j, int k, Ent newEnt)
 {
-    Ent prevEnt = _entGrid.HasEnt(i, j, k) ? _entGrid.GetEnt(i, j, k) : (Ent) { 0 };
+    Ent prevEnt = _entGrid.HasEnt(i, j, k) ? _entGrid.GetEnt(i, j, k) : Ent{ 0 };
     _Execute(std::static_pointer_cast<Action>(
         std::make_shared<EntAction>(i, j, k, _entGrid.HasEnt(i, j, k), false, prevEnt, newEnt)
     ));
@@ -76,7 +77,7 @@ void MapMan::ExecuteEntPlacement(int i, int j, int k, Ent newEnt)
 void MapMan::ExecuteEntRemoval(int i, int j, int k)
 {
     _Execute(std::static_pointer_cast<Action>(
-        std::make_shared<EntAction>(i, j, k, true, true, _entGrid.GetEnt(i, j, k), (Ent){ 0 })
+        std::make_shared<EntAction>(i, j, k, true, true, _entGrid.GetEnt(i, j, k), Ent{ 0 })
     ));
 }
 
@@ -212,9 +213,9 @@ bool MapMan::ExportGLTFScene(fs::path filePath, bool separateGeometry)
 
             //Calculate max and min component values. Required only for position buffer.
             float minX, minY, minZ;
-            minX = minY = minZ = __FLT_MAX__;
+            minX = minY = minZ = std::numeric_limits<float>::max();
             float maxX, maxY, maxZ;
-            maxX = maxY = maxZ = __FLT_MIN__;
+            maxX = maxY = maxZ = std::numeric_limits<float>::min();
             for (int j = 0; j < mapModel.meshes[i].vertexCount * 3; ++j)
             {
                 const float C = mapModel.meshes[i].vertices[j];

--- a/src/map_man.hpp
+++ b/src/map_man.hpp
@@ -24,6 +24,8 @@
 #include <deque>
 #include <cstdint>
 #include <memory>
+#include <stdint.h>
+#include <limits>
 #include <filesystem>
 namespace fs = std::filesystem;
 
@@ -160,7 +162,7 @@ public:
     {
         size_t minX, minY, minZ;
         size_t maxX, maxY, maxZ;
-        minX = minY = minZ = UINT64_MAX;
+        minX = minY = minZ = std::numeric_limits<size_t>::max();
         maxX = maxY = maxZ = 0;
         for (size_t x = 0; x < _tileGrid.GetWidth(); ++x)
         {

--- a/src/math_stuff.hpp
+++ b/src/math_stuff.hpp
@@ -27,8 +27,8 @@
 #include "rlgl.h"
 #include "raymath.h"
 
-const Vector3 VEC3_UP = (Vector3) { 0.0f, 1.0f, 0.0f };
-const Vector3 VEC3_FORWARD = (Vector3) { 0.0f, 0.0f, -1.0f };
+const Vector3 VEC3_UP = Vector3 { 0.0f, 1.0f, 0.0f };
+const Vector3 VEC3_FORWARD = Vector3 { 0.0f, 0.0f, -1.0f };
 
 //Returns the parameter that is lower in value.
 inline int Min(int a, int b) {
@@ -48,7 +48,7 @@ inline int Sign(int a) {
 
 inline Rectangle CenteredRect(float x, float y, float w, float h)
 {
-    return (Rectangle) { x - (w / 2.0f), y - (h / 2.0f), w, h };
+    return Rectangle{ x - (w / 2.0f), y - (h / 2.0f), w, h };
 }
 
 inline float ToRadians(float degrees)
@@ -67,7 +67,7 @@ inline int OffsetDegrees(int base, int add)
     return (base + add >= 0) ? (base + add) % 360 : (360 + (base + add));
 }
 
-inline Matrix MatrixRotYDeg(int degrees)
+inline Matrix MatrixRotYDeg(float degrees)
 {
     return MatrixRotateY(ToRadians(degrees));
 }

--- a/src/menu_bar.cpp
+++ b/src/menu_bar.cpp
@@ -33,70 +33,62 @@ namespace fs = std::filesystem;
 #define BUTTON_MARGIN 4.0f
 #define MENUBAR_FONT_SIZE 24.0f
 
-MenuBar::MenuBar(App::Settings &settings)
+MenuBar::MenuBar(App::Settings& settings)
     : _settings(settings),
-      _focused(false),
-      _activeMenu(nullptr),
-      _activeDialog(nullptr),
-      _messageTimer(0.0f),
-      _messagePriority(0)
+    _focused(false),
+    _activeMenu(nullptr),
+    _activeDialog(nullptr),
+    _messageTimer(0.0f),
+    _messagePriority(0)
 {
-    _menus = {
-        (Menu) {
-            .name = "MAP",
-            .items = {
-                (Item) { "NEW",          [&](){ _activeDialog.reset(new NewMapDialog()); } },
-                (Item) { "OPEN",         [&]()
-                    { 
-                        auto callback = [](fs::path path){ App::Get()->TryOpenMap(path); };
-                        _activeDialog.reset(new FileDialog("Open Map (*.te3)", { ".te3" }, callback)); 
-                    } 
-                },
-                (Item) { "SAVE",         [&]()
-                    { 
-                        if (!App::Get()->GetLastSavedPath().empty())
-                        {
-                            App::Get()->TrySaveMap(App::Get()->GetLastSavedPath());
-                        }
-                        else
-                        {
-                            OpenSaveMapDialog();
-                        }
-                    } 
-                },
-                (Item) { "SAVE AS",      [&](){ OpenSaveMapDialog(); } },
-                (Item) { "EXPORT",       [&](){ _activeDialog.reset(new ExportDialog(_settings)); }},
-                (Item) { "EXPAND GRID",  [&](){ _activeDialog.reset(new ExpandMapDialog()); } },
-                (Item) { "SHRINK GRID",  [&](){ _activeDialog.reset(new ShrinkMapDialog()); } },
-            },
-        },
-        (Menu) {
-            .name = "VIEW",
-            .items = {
-                (Item) { "MAP EDITOR",     [](){ App::Get()->ChangeEditorMode(App::Mode::PLACE_TILE); } },
-                (Item) { "TEXTURE PICKER", [](){ App::Get()->ChangeEditorMode(App::Mode::PICK_TEXTURE); } },
-                (Item) { "SHAPE PICKER",   [](){ App::Get()->ChangeEditorMode(App::Mode::PICK_SHAPE); } },
-                (Item) { "ENTITY EDITOR",  [](){ App::Get()->ChangeEditorMode(App::Mode::EDIT_ENT); } },
-                (Item) { "RESET CAMERA",   [](){ App::Get()->ResetEditorCamera(); } },
-                (Item) { "TOGGLE PREVIEW", [](){ App::Get()->TogglePreviewing(); } },
-            },
-        },
-        (Menu) {
-            .name = "CONFIG",
-            .items = {
-                (Item) { "ASSET PATHS", [&](){ _activeDialog.reset(new AssetPathDialog(_settings)); } },
-                (Item) { "SETTINGS",    [&](){ _activeDialog.reset(new SettingsDialog(_settings)); } },
-            },
-        },
-        (Menu) {
-            .name = "INFO",
-            .items = {
-                (Item) { "ABOUT",          [&](){ _activeDialog.reset(new AboutDialog()); } },
-                (Item) { "KEYS/SHORTCUTS", [&](){ _activeDialog.reset(new ShortcutsDialog()); } },
-                (Item) { "INSTRUCTIONS",   [&](){ _activeDialog.reset(new InstructionsDialog()); } },
-            },
-        }
-    };
+    //map menu
+    Menu mapMenu = { "MAP" };
+    mapMenu.items.push_back(Item{ "NEW",          [&]() { _activeDialog.reset(new NewMapDialog()); } });
+    mapMenu.items.push_back(Item{ "OPEN",         [&](){
+                                                    auto callback = [](fs::path path) { App::Get()->TryOpenMap(path); };
+                                                    _activeDialog.reset(new FileDialog("Open Map (*.te3)", { ".te3" }, callback));
+                                                }
+                                            });
+    mapMenu.items.push_back(Item { "SAVE",        [&]() {
+                                                        if (!App::Get()->GetLastSavedPath().empty())
+                                                        {
+                                                            App::Get()->TrySaveMap(App::Get()->GetLastSavedPath());
+                                                        }
+                                                        else
+                                                        {
+                                                            OpenSaveMapDialog();
+                                                        }
+                                                    }
+                                                });
+    mapMenu.items.push_back(Item{ "SAVE AS",      [&]() { OpenSaveMapDialog(); } });
+    mapMenu.items.push_back(Item{ "EXPORT",       [&]() { _activeDialog.reset(new ExportDialog(_settings)); } });
+    mapMenu.items.push_back(Item{ "EXPAND GRID",  [&]() { _activeDialog.reset(new ExpandMapDialog()); } });
+    mapMenu.items.push_back(Item{ "SHRINK GRID",  [&]() { _activeDialog.reset(new ShrinkMapDialog()); } });
+    _menus.push_back(mapMenu);
+
+    //view menu
+    Menu view = { "VIEW" };
+    view.items.push_back(Item{ "MAP EDITOR",     []() { App::Get()->ChangeEditorMode(App::Mode::PLACE_TILE); } });
+    view.items.push_back(Item{ "TEXTURE PICKER", []() { App::Get()->ChangeEditorMode(App::Mode::PICK_TEXTURE); } });
+    view.items.push_back(Item{ "SHAPE PICKER",   []() { App::Get()->ChangeEditorMode(App::Mode::PICK_SHAPE); } });
+    view.items.push_back(Item{ "ENTITY EDITOR",  []() { App::Get()->ChangeEditorMode(App::Mode::EDIT_ENT); } });
+    view.items.push_back(Item{ "RESET CAMERA",   []() { App::Get()->ResetEditorCamera(); } });
+    view.items.push_back(Item{ "TOGGLE PREVIEW", []() { App::Get()->TogglePreviewing(); } });
+    _menus.push_back(view);
+
+    //config menu
+    Menu config = { "CONFIG" };
+    config.items.push_back(Item{ "ASSET PATHS", [&]() { _activeDialog.reset(new AssetPathDialog(_settings)); } });
+    config.items.push_back(Item{ "SETTINGS",    [&]() { _activeDialog.reset(new SettingsDialog(_settings)); } });
+    _menus.push_back(config);
+
+    // info menu
+    Menu info = { "INFO" };
+    info.items.push_back(Item{ "ABOUT", [&]() { _activeDialog.reset(new AboutDialog()); } });
+    info.items.push_back(Item{ "KEYS/SHORTCUTS", [&]() { _activeDialog.reset(new ShortcutsDialog()); } });
+    info.items.push_back(Item{ "INSTRUCTIONS", [&]() { _activeDialog.reset(new InstructionsDialog()); } });
+
+    _menus.push_back(info);
 
     for (Menu &menu : _menus)
     {
@@ -117,7 +109,7 @@ void MenuBar::OpenSaveMapDialog()
 
 void MenuBar::Update()
 {
-    _topBar = (Rectangle) { 0, 0, (float)GetScreenWidth(), 32 };
+    _topBar = Rectangle { 0, 0, (float)GetScreenWidth(), 32 };
 
     if (_messageTimer > 0.0f)
     {
@@ -171,11 +163,11 @@ std::string MenuBar::_GetMenuString(const MenuBar::Menu &menu) const
 void MenuBar::Draw()
 {
     DrawRectangleGradientV(_topBar.x, _topBar.y, _topBar.width, _topBar.height, GRAY, DARKGRAY);
-    const Rectangle MENU_BOUNDS = (Rectangle) { _topBar.x, _topBar.y, _topBar.width / 2.0f, _topBar.height };
+    const Rectangle MENU_BOUNDS = Rectangle { _topBar.x, _topBar.y, _topBar.width / 2.0f, _topBar.height };
     
     if (_messageTimer > 0.0f)
     {
-        DrawTextEx(Assets::GetFont(), _statusMessage.c_str(), (Vector2) { MENU_BOUNDS.x + MENU_BOUNDS.width + 4, 2 }, MENUBAR_FONT_SIZE, 0.0f, WHITE);
+        DrawTextEx(Assets::GetFont(), _statusMessage.c_str(), Vector2{ MENU_BOUNDS.x + MENU_BOUNDS.width + 4, 2 }, MENUBAR_FONT_SIZE, 0.0f, WHITE);
     }
 
     const float BUTTON_WIDTH = (MENU_BOUNDS.width / _menus.size()) - (BUTTON_MARGIN * 2.0f);
@@ -183,7 +175,7 @@ void MenuBar::Draw()
     float x = BUTTON_MARGIN;
     for (auto &menu : _menus)
     {
-        const Rectangle BUTT_RECT = (Rectangle) { MENU_BOUNDS.x + x, MENU_BOUNDS.y, BUTTON_WIDTH, MENU_BOUNDS.height }; //Heehee! Butt!
+        const Rectangle BUTT_RECT = Rectangle { MENU_BOUNDS.x + x, MENU_BOUNDS.y, BUTTON_WIDTH, MENU_BOUNDS.height }; //Heehee! Butt!
 
         std::string name = menu.name;
         //Abbreviate tab names when window is too small.
@@ -204,13 +196,13 @@ void MenuBar::Draw()
         if (_activeMenu == &menu)
         {
             std::string list = _GetMenuString(menu);
-            Rectangle listBounds = (Rectangle) { 
+            Rectangle listBounds = Rectangle { 
                 .x = BUTT_RECT.x, 
                 .y = BUTT_RECT.y + BUTT_RECT.height, 
-                .width = Max(BUTT_RECT.width, menu.width + BUTTON_MARGIN), 
+                .width = float(Max(BUTT_RECT.width, menu.width + BUTTON_MARGIN)), 
                 .height = 28.0f * menu.items.size() };
                 
-            _activeMenuBounds = (Rectangle) {
+            _activeMenuBounds = Rectangle {
                 .x = listBounds.x, 
                 .y = BUTT_RECT.y,
                 .width = listBounds.width,

--- a/src/pick_mode.cpp
+++ b/src/pick_mode.cpp
@@ -57,19 +57,18 @@ void PickMode::_GetFrames(std::string rootDir)
         std::string dir = dirs.top();
         dirs.pop();
 
-        char **files = nullptr;
-        int fileCount = 0;
+        FilePathList files = { 0 };
         //This function will free the memory stored in `files` every time it is called, so be careful not to call it during iteration.
-        files = GetDirectoryFiles(dir.c_str(), &fileCount);
+        files = LoadDirectoryFiles(dir.c_str());
 
-        for (int f = 0; f < fileCount; ++f)
+        for (int f = 0; f < files.count; ++f)
         {
-            std::string fullPath = BuildPath({dir, files[f]});
-            if (DirectoryExists(fullPath.c_str()) && strcmp(files[f], ".") != 0 && strcmp(files[f], "..") != 0)
+            std::string fullPath = BuildPath({dir, files.paths[f]});
+            if (DirectoryExists(fullPath.c_str()) && strcmp(files.paths[f], ".") != 0 && strcmp(files.paths[f], "..") != 0)
             {
                 dirs.push(fullPath);
             }
-            else if (_mode == Mode::TEXTURES && IsFileExtension(files[f], ".png"))
+            else if (_mode == Mode::TEXTURES && IsFileExtension(files.paths[f], ".png"))
             {
                 Frame frame = {
                     .tex = LoadTexture(fullPath.c_str()),
@@ -78,7 +77,7 @@ void PickMode::_GetFrames(std::string rootDir)
                 };
                 _frames.push_back(frame);
             }
-            else if (_mode == Mode::SHAPES && IsFileExtension(files[f], ".obj"))
+            else if (_mode == Mode::SHAPES && IsFileExtension(files.paths[f], ".obj"))
             {
                 ModelID shape = Assets::ModelIDFromPath(fullPath);
                 Frame frame = {
@@ -87,8 +86,12 @@ void PickMode::_GetFrames(std::string rootDir)
                 _frames.push_back(frame);
             }
 
-            if (fullPath.length() > _longestLabelLength) _longestLabelLength = fullPath.length();
+            if (fullPath.length() > _longestLabelLength)
+                _longestLabelLength = fullPath.length();
+
+     
         }
+        UnloadDirectoryFiles(files);
     }
 }
 
@@ -101,8 +104,6 @@ void PickMode::OnEnter()
         _GetFrames(App::Get()->GetTexturesDir());
     else if (_mode == Mode::SHAPES)
         _GetFrames(App::Get()->GetShapesDir());
-
-    ClearDirectoryFiles();
 }
 
 void PickMode::OnExit()
@@ -133,7 +134,7 @@ void PickMode::Update()
 void PickMode::_DrawGridView(Rectangle framesView) 
 {
     const int FRAMES_PER_ROW = (int)framesView.width / FRAME_SPACING;
-    Rectangle framesContent = (Rectangle){
+    Rectangle framesContent = Rectangle{
         .x = 0, 
         .y = 0, 
         .width = framesView.width - 16, 
@@ -148,7 +149,7 @@ void PickMode::_DrawGridView(Rectangle framesView)
         int f = 0;
         for (Frame *frame : _filteredFrames)
         {
-            Rectangle rect = (Rectangle){
+            Rectangle rect = Rectangle{
                 .x = framesView.x + FRAME_MARGIN + (f % FRAMES_PER_ROW) * FRAME_SPACING + _scroll.x,
                 .y = framesView.y + FRAME_MARGIN + (f / FRAMES_PER_ROW) * FRAME_SPACING + _scroll.y,
                 .width = FRAME_SIZE,
@@ -167,7 +168,7 @@ void PickMode::_DrawListView(Rectangle framesView)
     const int SPACING_WITH_LABEL = FRAME_SPACING + (_longestLabelLength * 10) + 8;
     int framesPerRow = (int)floorf(framesView.width / SPACING_WITH_LABEL);
     if (framesPerRow < 1) framesPerRow = 1;
-    Rectangle framesContent = (Rectangle){ 
+    Rectangle framesContent = Rectangle{ 
         .x = 0, 
         .y = 0, 
         .width = framesView.width - 16, 
@@ -180,7 +181,7 @@ void PickMode::_DrawListView(Rectangle framesView)
         int f = 0;
         for (Frame *frame : _filteredFrames)
         {
-            Rectangle rect = (Rectangle){
+            Rectangle rect = Rectangle{
                 .x = framesView.x + FRAME_MARGIN + (f % framesPerRow) * SPACING_WITH_LABEL + _scroll.x,
                 .y = framesView.y + FRAME_MARGIN + (f / framesPerRow) * FRAME_SPACING + _scroll.y,
                 .width = FRAME_SIZE,
@@ -190,10 +191,10 @@ void PickMode::_DrawListView(Rectangle framesView)
 
             _DrawFrame(frame, rect);
 
-            Rectangle labelRect = (Rectangle){
+            Rectangle labelRect = Rectangle{
                 .x = rect.x + rect.width + FRAME_MARGIN,
                 .y = rect.y,
-                .width = SPACING_WITH_LABEL - FRAME_SPACING,
+                .width = float(SPACING_WITH_LABEL - FRAME_SPACING),
                 .height = rect.height
             };
             if (GuiLabelButton(labelRect, frame->label.c_str())) 
@@ -212,7 +213,7 @@ void PickMode::_DrawFrame(Frame *frame, Rectangle rect)
         _selectedFrame = frame;
     }
 
-    Rectangle outline = (Rectangle){rect.x - 2, rect.y - 2, rect.width + 4, rect.height + 4};
+    Rectangle outline = Rectangle{rect.x - 2, rect.y - 2, rect.width + 4, rect.height + 4};
     DrawRectangle(outline.x, outline.y, outline.width, outline.height, BLACK); //Black background
     
     //Texture
@@ -228,21 +229,21 @@ void PickMode::_DrawFrame(Frame *frame, Rectangle rect)
 void PickMode::Draw()
 {
     //Draw search box
-    GuiLabel((Rectangle){32, UPPER_MARGIN, 128, 32}, "SEARCH:");
-    Rectangle searchBoxRect = (Rectangle){128, UPPER_MARGIN, (float)GetScreenWidth() / 3.0f, 32};
+    GuiLabel(Rectangle{32, UPPER_MARGIN, 128, 32}, "SEARCH:");
+    Rectangle searchBoxRect = Rectangle{128, UPPER_MARGIN, (float)GetScreenWidth() / 3.0f, 32};
     if (GuiTextBox(searchBoxRect, _searchFilterBuffer, SEARCH_BUFFER_SIZE, _searchFilterFocused))
     {
         _searchFilterFocused = !_searchFilterFocused;
     }
     
     //Clear button
-    Rectangle clearButtonRect = (Rectangle){searchBoxRect.x + searchBoxRect.width + 4, searchBoxRect.y, 96, 32};
+    Rectangle clearButtonRect = Rectangle{searchBoxRect.x + searchBoxRect.width + 4, searchBoxRect.y, 96, 32};
     if (GuiButton(clearButtonRect, "Clear"))
     {
         memset(_searchFilterBuffer, 0, SEARCH_BUFFER_SIZE * sizeof(char));
     }
     //Viewing types selection
-    Rectangle viewToggleRect = (Rectangle){
+    Rectangle viewToggleRect = Rectangle{
         .x = (float)GetScreenWidth() - 32 - 128, 
         .y = clearButtonRect.y,
         .width = 64,
@@ -250,7 +251,7 @@ void PickMode::Draw()
         };
     _view = (View)GuiToggleGroup(viewToggleRect, "GRID;LIST", (int)_view);
 
-    Rectangle framesView = (Rectangle){32, 96, (float)GetScreenWidth() - 64, (float)GetScreenHeight() - 128};
+    Rectangle framesView = Rectangle{32, 96, (float)GetScreenWidth() - 64, (float)GetScreenHeight() - 128};
     if (_view == View::GRID) _DrawGridView(framesView);
     else if (_view == View::LIST) _DrawListView(framesView);
 
@@ -259,7 +260,7 @@ void PickMode::Draw()
     {
         std::string selectString = std::string("Selected: ") + _selectedFrame->label;
 
-        GuiLabel((Rectangle){
+        GuiLabel(Rectangle{
                     .x = 64, 
                     .y = (float)GetScreenHeight() - 24, 
                     .width = (float)GetScreenWidth() / 2.0f, 

--- a/src/place_mode.cpp
+++ b/src/place_mode.cpp
@@ -53,7 +53,7 @@ PlaceMode::PlaceMode(MapMan &mapMan)
     _cursor.tile.pitch = 0;
 
     _cursor.brush = TileGrid(1, 1, 1);
-    _cursor.ent = (Ent) {
+    _cursor.ent = Ent {
         .color = WHITE,
         .radius = 1.0f
     };
@@ -87,7 +87,7 @@ void PlaceMode::ResetCamera()
 void PlaceMode::ResetGrid()
 {
     //Editor grid and plane
-    _planeGridPos = (Vector3){ (float)_mapMan.Tiles().GetWidth() / 2.0f, 0, (float)_mapMan.Tiles().GetLength() / 2.0f };
+    _planeGridPos = Vector3{ (float)_mapMan.Tiles().GetWidth() / 2.0f, 0, (float)_mapMan.Tiles().GetLength() / 2.0f };
     _planeWorldPos = _mapMan.Tiles().GridToWorldPos(_planeGridPos, false);
     _layerViewMin = 0;
     _layerViewMax = _mapMan.Tiles().GetHeight() - 1;
@@ -176,10 +176,10 @@ void PlaceMode::UpdateCursor()
     Vector3 gridMin = _mapMan.Tiles().GetMinCorner();
     Vector3 gridMax = _mapMan.Tiles().GetMaxCorner();
     RayCollision col = GetRayCollisionQuad(pickRay, 
-        (Vector3){ gridMin.x, _planeWorldPos.y, gridMin.z }, 
-        (Vector3){ gridMax.x, _planeWorldPos.y, gridMin.z }, 
-        (Vector3){ gridMax.x, _planeWorldPos.y, gridMax.z }, 
-        (Vector3){ gridMin.x, _planeWorldPos.y, gridMax.z });
+        Vector3{ gridMin.x, _planeWorldPos.y, gridMin.z }, 
+        Vector3{ gridMax.x, _planeWorldPos.y, gridMin.z }, 
+        Vector3{ gridMax.x, _planeWorldPos.y, gridMax.z }, 
+        Vector3{ gridMin.x, _planeWorldPos.y, gridMax.z });
     if (col.hit)
     {
         _cursor.endPosition = _mapMan.Tiles().SnapToCelCenter(col.point);
@@ -226,7 +226,7 @@ void PlaceMode::UpdateCursor()
 
     if (_cursor.mode == Cursor::Mode::BRUSH)
     {
-        _cursor.startPosition = (Vector3) {
+        _cursor.startPosition = Vector3 {
             _cursor.endPosition.x + (_cursor.brush.GetWidth()  - 1) * _cursor.brush.GetSpacing(),
             _cursor.endPosition.y + (_cursor.brush.GetHeight() - 1) * _cursor.brush.GetSpacing(),
             _cursor.endPosition.z + (_cursor.brush.GetLength() - 1) * _cursor.brush.GetSpacing(),
@@ -283,13 +283,13 @@ void PlaceMode::UpdateCursor()
             //Remove tiles
             if (underTile)
             {
-                _mapMan.ExecuteTileAction(i, j, k, 1, 1, 1, (Tile) {NO_MODEL, 0, NO_TEX, false});
+                _mapMan.ExecuteTileAction(i, j, k, 1, 1, 1, Tile {NO_MODEL, 0, NO_TEX, false});
             }
         } 
         else if (IsMouseButtonReleased(MOUSE_BUTTON_RIGHT) && multiSelect)
         {
             //Remove tiles RECTANGLE
-            _mapMan.ExecuteTileAction(i, j, k, w, h, l, (Tile) {NO_MODEL, 0, NO_TEX, false});
+            _mapMan.ExecuteTileAction(i, j, k, w, h, l, Tile {NO_MODEL, 0, NO_TEX, false});
         }
         else if (IsKeyDown(KEY_G) && !multiSelect) 
         {
@@ -439,7 +439,7 @@ void PlaceMode::Draw()
             rlDrawRenderBatchActive();
             rlSetLineWidth(1.0f);
             DrawGridEx(
-                Vector3Add(_planeWorldPos, (Vector3){ 0.0f, 0.05f, 0.0f }), //Adding the offset to prevent Z-fighting 
+                Vector3Add(_planeWorldPos, Vector3{ 0.0f, 0.05f, 0.0f }), //Adding the offset to prevent Z-fighting 
                 _mapMan.Tiles().GetWidth()+1, _mapMan.Tiles().GetLength()+1, 
                 _mapMan.Tiles().GetSpacing());
             rlDrawRenderBatchActive();
@@ -491,7 +491,7 @@ void PlaceMode::Draw()
                 fabs(_cursor.endPosition.z - _cursor.startPosition.z) + _mapMan.Tiles().GetSpacing() * _cursor.outlineScale, 
                 MAGENTA);
 
-            DrawAxes3D((Vector3){ 1.0f, 1.0f, 1.0f }, 10.0f);
+            DrawAxes3D(Vector3{ 1.0f, 1.0f, 1.0f }, 10.0f);
             rlDrawRenderBatchActive();
             rlEnableDepthTest();
         }

--- a/src/text_util.hpp
+++ b/src/text_util.hpp
@@ -46,7 +46,7 @@ inline int GetStringWidth(Font font, float fontSize, const std::string &string)
     float scaleFactor = fontSize / font.baseSize;
     int maxWidth = 0;
     int lineWidth = 0;
-    for (int i = 0; i < string.size();)
+    for (int i = 0; i < int(string.size());)
     {
         int codepointByteCount = 0;
         int codepoint = GetCodepoint(&string[i], &codepointByteCount);
@@ -61,8 +61,10 @@ inline int GetStringWidth(Font font, float fontSize, const std::string &string)
         }
         else 
         {
-            if (font.glyphs[g].advanceX == 0) lineWidth += ((float)font.recs[g].width*scaleFactor);
-            else lineWidth += ((float)font.glyphs[g].advanceX*scaleFactor);
+            if (font.glyphs[g].advanceX == 0) 
+                lineWidth += int(font.recs[g].width*scaleFactor);
+            else 
+                lineWidth += int(font.glyphs[g].advanceX*scaleFactor);
         }
 
         i += codepointByteCount;

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -41,9 +41,12 @@ void TileGrid::_RegenBatches(Vector3 position, int fromY, int toY)
     //Create a hash map of dynamic arrays for each combination of texture and mesh
     for (int y = fromY; y <= toY; ++y)
     {
-        for (size_t t = y * layerArea; t < (y + 1) * layerArea; ++t) {
+        for (size_t t = y * layerArea; t < (y + 1) * layerArea; ++t) 
+        {
             const Tile& tile = _grid[t];
-            if (tile) {
+            if (tile)
+            
+            {
                 //Calculate world space matrix for the tile
                 Vector3 gridPos = UnflattenIndex(t);
                 Vector3 worldPos = Vector3Add(position, GridToWorldPos(gridPos, true));
@@ -52,10 +55,12 @@ void TileGrid::_RegenBatches(Vector3 position, int fromY, int toY)
                     MatrixTranslate(worldPos.x, worldPos.y, worldPos.z));
 
                 const Model &shape = Assets::ModelFromID(tile.shape);
-                for (size_t m = 0; m < shape.meshCount; ++m) {
+                for (int m = 0; m < shape.meshCount; ++m) 
+                {
                     //Add the tile's transform to the instance arrays for each mesh
                     auto pair = std::make_pair(tile.texture, &shape.meshes[m]);
-                    if (_drawBatches.find(pair) == _drawBatches.end()) {
+                    if (_drawBatches.find(pair) == _drawBatches.end()) 
+                    {
                         //Put in a vector for this pair if there hasn't been one already
                         _drawBatches[pair] = std::vector<Matrix>();
                     }
@@ -163,7 +168,7 @@ Model *TileGrid::_GenerateModel()
         auto [iter, succ] = usedTexIDs.insert(pair.first);
         if (succ)
         {
-            meshMap[pair.first] = (DynMesh) {};
+            meshMap[pair.first] = DynMesh {};
             meshMap[pair.first].triCount = 0;
         }
         Mesh &shape = *pair.second;
@@ -178,7 +183,7 @@ Model *TileGrid::_GenerateModel()
                 if (shape.vertices != NULL)
                 {
                     //Transform shape vertices into tile's orientation and position
-                    Vector3 vec = (Vector3) { shape.vertices[v*3], shape.vertices[v*3 + 1], shape.vertices[v*3 + 2] };
+                    Vector3 vec = Vector3 { shape.vertices[v*3], shape.vertices[v*3 + 1], shape.vertices[v*3 + 2] };
                     vec = Vector3Transform(vec, matrix);
                     mesh.positions.push_back(vec.x);
                     mesh.positions.push_back(vec.y);
@@ -193,7 +198,7 @@ Model *TileGrid::_GenerateModel()
                     rotMatrix.m13 = 0.0f;
                     rotMatrix.m14 = 0.0f;
                     
-                    Vector3 norm = (Vector3) { shape.normals[v*3], shape.normals[v*3 + 1], shape.normals[v*3 + 2] };
+                    Vector3 norm = Vector3 { shape.normals[v*3], shape.normals[v*3 + 1], shape.normals[v*3 + 2] };
                     norm = Vector3Transform(norm, rotMatrix);
                     mesh.normals.push_back(norm.x);
                     mesh.normals.push_back(norm.y);
@@ -247,7 +252,7 @@ Model *TileGrid::_GenerateModel()
 
         //Copy mesh data into Raylib mesh
         DynMesh &dMesh = meshMap[*texID];
-        model->meshes[i] = (Mesh) { 0 };
+        model->meshes[i] = Mesh { 0 };
         model->meshes[i].vertexCount = dMesh.positions.size() / 3;
         model->meshes[i].triangleCount = dMesh.triCount;
         

--- a/src/tile.hpp
+++ b/src/tile.hpp
@@ -71,7 +71,7 @@ inline bool operator!=(const Tile &lhs, const Tile &rhs)
 inline Matrix TileRotationMatrix(const Tile &tile)
 {
     return MatrixMultiply( 
-        MatrixRotateX(ToRadians(tile.pitch)), MatrixRotYDeg(tile.angle));
+        MatrixRotateX(ToRadians(float(tile.pitch))), MatrixRotYDeg(float(tile.angle)));
 }
 
 class TileGrid : public Grid<Tile>
@@ -84,7 +84,7 @@ public:
     }
     //Constructs a TileGrid full of empty tiles.
     inline TileGrid(size_t width, size_t height, size_t length)
-        : TileGrid(width, height, length, TILE_SPACING_DEFAULT, (Tile) { NO_MODEL, 0, NO_TEX, false })
+        : TileGrid(width, height, length, TILE_SPACING_DEFAULT, Tile { NO_MODEL, 0, NO_TEX, false })
     {
     }
 
@@ -111,7 +111,7 @@ public:
     inline void SetTileRect(int i, int j, int k, int w, int h, int l, const Tile& tile)
     {
         assert(i >= 0 && j >= 0 && k >= 0);
-        assert(i + w <= _width && j + h <= _height && k + l <= _length);
+        assert(i + w <= int(_width) && j + h <= int(_height) && k + l <= int(_length));
         for (int y = j; y < j + h; ++y)
         {
             for (int z = k; z < k + l; ++z)
@@ -133,9 +133,9 @@ public:
     inline void CopyTiles(int i, int j, int k, const TileGrid &src, bool ignoreEmpty = false)
     {
         assert(i >= 0 && j >= 0 && k >= 0);
-        int xEnd = Min(i + src._width, _width); 
-        int yEnd = Min(j + src._height, _height);
-        int zEnd = Min(k + src._length, _length);
+        int xEnd = Min(i + int(src._width), int(_width));
+        int yEnd = Min(j + int(src._height), int(_height));
+        int zEnd = Min(k + int(src._length), int(_length));
         for (int z = k; z < zEnd; ++z) 
         {
             for (int y = j; y < yEnd; ++y)
@@ -172,7 +172,7 @@ public:
     inline TileGrid Subsection(int i, int j, int k, int w, int h, int l) const
     {
         assert(i >= 0 && j >= 0 && k >= 0);
-        assert(i + w <= _width && j + h <= _height && k + l <= _length);
+        assert(i + w <= int(_width) && j + h <=int(_height) && k + l <= int(_length));
 
         TileGrid newGrid(w, h, l);
 


### PR DESCRIPTION
This PR makes code changes to let the code build in Visual Studio.

Main changes are.

- Correct brace initialization, (Vector2){} to Vector2{}
- Casting
- Don't use brace initialization for menus (some bug in VS prevents this from working)
- Update to use current raylib release.

This PR does not include a build system for Visual Studio.  If that is desired I have ported the project to use premake and that will create makefiles for gcc and projects for visual studio